### PR TITLE
Fix getSyms symbol request import

### DIFF
--- a/getSyms.py
+++ b/getSyms.py
@@ -10,7 +10,8 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 from ctrader_open_api.client import ClientService
 from ctrader_open_api.client import Client
 from ctrader_open_api.factory import Factory
-from ctrader_open_api.protobuf_model import ProtoOASymbolListReq
+# Symbol list request message generated from the Open API protobuf definitions
+from ctrader_open_api.messages.OpenApiMessages_pb2 import ProtoOASymbolsListReq
 
 # Load credentials from file
 creds_path = os.path.join(os.path.dirname(__file__), "credentials/creds.json")
@@ -59,7 +60,7 @@ client_service.startService(
     access_token=creds["accessToken"]
 )
 
-symbol_list_request = ProtoOASymbolListReq(
+symbol_list_request = ProtoOASymbolsListReq(
     ctidTraderAccountId=creds["accountId"]
 )
 client.send(symbol_list_request)


### PR DESCRIPTION
## Summary
- simplify comment for symbol list import

## Testing
- `python3 -m py_compile getSyms.py`
- `python3 getSyms.py` *(fails: TypeError from ClientService)*

------
https://chatgpt.com/codex/tasks/task_e_68469712abc083339bba7c46ded80af9